### PR TITLE
Add lightning whisper MLX STT server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.env
+.venv

--- a/README.md
+++ b/README.md
@@ -1,2 +1,84 @@
 # lightning-owhisper-mlx
-A clone of owhisper from from Hyprnote that uses lightning-whisper-mlx instead of whisper.cpp.
+
+Lightning-OWhisper-MLX is a Deepgram-compatible speech-to-text server tailored
+for [Hyprnote](https://github.com/fastrepl/hyprnote). It mirrors the public
+surface of `owhisper` while replacing the inference backend with
+[`lightning-whisper-mlx`](https://github.com/mustafaaljadery/lightning-whisper-mlx)
+so you can run fast Whisper models on Apple Silicon.
+
+## Features
+
+- **Deepgram compatible API** – implements the `/listen`, `/v1/listen`,
+  `/models`, `/v1/models`, `/health`, and `/v1/status` endpoints used by
+  Hyprnote.
+- **WebSocket streaming** – accepts 16 kHz PCM audio and emits Deepgram style
+  transcript messages with word-level metadata.
+- **Multiple model support** – load any lightning-whisper-mlx model, including
+  quantized variants.
+- **API key optional** – require `Token` or `Bearer` authorization headers with
+  a single config value.
+
+## Installation
+
+```bash
+pip install lightning-owhisper-mlx
+# Install the MLX backend (optional on non-Apple platforms)
+pip install "lightning-owhisper-mlx[mlx]"
+```
+
+## Configuration
+
+The server reads a simple YAML file describing available models. By default it
+exposes two distilled English models, but you can provide your own configuration
+via the `--config` flag.
+
+```yaml
+# config.yaml
+general:
+  api_key: super-secret-token
+  host: 0.0.0.0
+  port: 52693
+  sample_rate: 16000
+models:
+  - id: distil-medium-en
+    model: distil-medium.en
+    batch_size: 12
+  - id: turbo-en
+    model: large-v3
+    quantization: 8bit
+    batch_size: 4
+```
+
+## Running the server
+
+```bash
+lightning-owhisper-mlx --config config.yaml
+```
+
+The CLI accepts `--host` and `--port` overrides for quick experiments. The
+server exposes the following Deepgram-compatible endpoints:
+
+| Method | Path          | Description              |
+| ------ | ------------- | ------------------------ |
+| GET    | `/health`     | Liveness probe           |
+| GET    | `/v1/status`  | Deepgram status endpoint |
+| GET    | `/models`     | List configured models   |
+| GET    | `/v1/models`  | Deepgram model list      |
+| WS     | `/listen`     | Streaming transcription  |
+| WS     | `/v1/listen`  | Deepgram streaming API   |
+
+Clients can connect using the existing Hyprnote owhisper client or any Deepgram
+compatible client. Audio should be 16 kHz little-endian PCM with one or two
+channels.
+
+## Development
+
+Install development dependencies and run the unit test suite:
+
+```bash
+pip install -e .
+pytest
+```
+
+The tests cover the audio segmentation logic and Deepgram response formatting so
+they run without requiring the MLX runtime.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,38 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "lightning-owhisper-mlx"
+version = "0.1.0"
+description = "Deepgram-compatible STT server using lightning-whisper-mlx"
+readme = "README.md"
+authors = [
+    {name = "Hyprnote"},
+]
+requires-python = ">=3.10"
+dependencies = [
+    "fastapi",
+    "uvicorn[standard]",
+    "numpy",
+    "pydantic>=2.0",
+    "pydantic-settings",
+    "anyio",
+    "pyyaml",
+    "huggingface-hub",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "httpx",
+]
+mlx = [
+    "lightning-whisper-mlx",
+]
+
+[project.scripts]
+lightning-owhisper-mlx = "lightning_owhisper_mlx.main:app"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/lightning_owhisper_mlx/__init__.py
+++ b/src/lightning_owhisper_mlx/__init__.py
@@ -1,0 +1,6 @@
+"""Lightning-Owhisper-MLX package."""
+
+from .config import AppConfig, ModelConfig
+from .server import create_app
+
+__all__ = ["AppConfig", "ModelConfig", "create_app"]

--- a/src/lightning_owhisper_mlx/config.py
+++ b/src/lightning_owhisper_mlx/config.py
@@ -1,0 +1,84 @@
+"""Configuration management for the Lightning OWhisper MLX server."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Optional
+
+import yaml
+from pydantic import BaseModel, Field, field_validator
+
+
+class ModelConfig(BaseModel):
+    """Configuration for a single speech-to-text model."""
+
+    id: str = Field(..., description="External identifier exposed in the API")
+    model: str = Field(..., description="Name passed to LightningWhisperMLX")
+    quantization: Optional[str] = Field(
+        default=None,
+        description="Optional quantization level (None, '4bit', '8bit')",
+    )
+    batch_size: int = Field(
+        default=12, description="Batch size forwarded to LightningWhisperMLX"
+    )
+
+    @field_validator("quantization")
+    @classmethod
+    def _validate_quant(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return value
+        if value not in {"4bit", "8bit"}:
+            raise ValueError("quantization must be either '4bit' or '8bit'")
+        return value
+
+
+class GeneralConfig(BaseModel):
+    """General server settings."""
+
+    api_key: Optional[str] = Field(
+        default=None,
+        description="Optional API key required for incoming requests.",
+    )
+    host: str = Field(default="127.0.0.1", description="Server host")
+    port: int = Field(default=52693, description="Server port")
+    sample_rate: int = Field(default=16000, description="Expected input sample rate")
+
+
+class AppConfig(BaseModel):
+    """Top-level configuration model."""
+
+    general: GeneralConfig = Field(default_factory=GeneralConfig)
+    models: List[ModelConfig] = Field(default_factory=list)
+
+    @classmethod
+    def from_file(cls, path: Path) -> "AppConfig":
+        """Load configuration from a YAML file."""
+
+        data = yaml.safe_load(path.read_text())
+        return cls(**data)
+
+    def require_model(self, model_id: str) -> ModelConfig:
+        """Return the model configuration matching *model_id*."""
+
+        for model in self.models:
+            if model.id == model_id:
+                return model
+        raise KeyError(f"Model '{model_id}' is not configured")
+
+
+DEFAULT_CONFIG = AppConfig(
+    models=[
+        ModelConfig(id="distil-medium-en", model="distil-medium.en"),
+        ModelConfig(id="distil-small-en", model="distil-small.en"),
+    ]
+)
+
+
+def load_config(path: Optional[Path]) -> AppConfig:
+    """Load configuration from *path* or return :data:`DEFAULT_CONFIG`."""
+
+    if path is None:
+        return DEFAULT_CONFIG
+    if not path.exists():
+        raise FileNotFoundError(f"Configuration file not found: {path}")
+    return AppConfig.from_file(path)

--- a/src/lightning_owhisper_mlx/main.py
+++ b/src/lightning_owhisper_mlx/main.py
@@ -1,0 +1,42 @@
+"""CLI entrypoint for running the server."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import uvicorn
+
+from .config import AppConfig, load_config
+from .server import create_app
+
+
+def _apply_cli_overrides(config: AppConfig, host: str | None, port: int | None) -> AppConfig:
+    data = config.model_dump()
+    if host is not None:
+        data.setdefault("general", {})["host"] = host
+    if port is not None:
+        data.setdefault("general", {})["port"] = port
+    return AppConfig.model_validate(data)
+
+
+def app() -> None:
+    parser = argparse.ArgumentParser(description="Run the Lightning OWhisper MLX server")
+    parser.add_argument("--config", type=Path, default=None, help="Path to configuration YAML")
+    parser.add_argument("--host", type=str, default=None, help="Override host from config")
+    parser.add_argument("--port", type=int, default=None, help="Override port from config")
+    args = parser.parse_args()
+
+    config = load_config(args.config)
+    config = _apply_cli_overrides(config, args.host, args.port)
+
+    uvicorn.run(
+        create_app(config),
+        host=config.general.host,
+        port=config.general.port,
+        log_level="info",
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app()

--- a/src/lightning_owhisper_mlx/responses.py
+++ b/src/lightning_owhisper_mlx/responses.py
@@ -1,0 +1,90 @@
+"""Helpers for constructing Deepgram compatible responses."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Dict, Optional
+
+import numpy as np
+
+from .segmenter import AudioSegment
+from .transcriber import TranscriptionResult
+
+
+def _word_confidence(word: Dict) -> float:
+    for key in ("confidence", "probability", "score", "avg_logprob"):
+        value = word.get(key)
+        if value is not None:
+            try:
+                return float(value)
+            except (TypeError, ValueError):
+                continue
+    return 0.0
+
+
+def build_transcript_response(
+    *,
+    result: TranscriptionResult,
+    segment: AudioSegment,
+    model_name: str,
+    total_channels: int,
+    request_id: str,
+    model_uuid: Optional[str] = None,
+) -> Dict:
+    """Return a Deepgram compatible transcript payload."""
+
+    model_uuid = model_uuid or uuid.uuid4().hex
+    words = []
+    confidences = []
+
+    for word in result.words:
+        start = segment.start_time + float(word.get("start", 0.0))
+        end = segment.start_time + float(word.get("end", start))
+        confidence = _word_confidence(word)
+        confidences.append(confidence)
+        words.append(
+            {
+                "word": word.get("word", ""),
+                "start": start,
+                "end": end,
+                "confidence": confidence,
+                "speaker": segment.channel_index if total_channels > 1 else None,
+                "punctuated_word": word.get("punctuated_word"),
+                "language": word.get("language"),
+            }
+        )
+
+    transcript_text = result.text.strip()
+    confidence = float(np.mean(confidences)) if confidences else 0.0
+    languages = []
+    if result.language:
+        languages = [result.language]
+
+    return {
+        "type": "Results",
+        "start": segment.start_time,
+        "duration": max(segment.end_time - segment.start_time, 0.0),
+        "is_final": True,
+        "speech_final": True,
+        "from_finalize": False,
+        "channel": {
+            "alternatives": [
+                {
+                    "transcript": transcript_text,
+                    "words": words,
+                    "confidence": confidence,
+                    "languages": languages,
+                }
+            ]
+        },
+        "metadata": {
+            "request_id": request_id,
+            "model_info": {
+                "name": model_name,
+                "version": "1.0",
+                "arch": "mlx",
+            },
+            "model_uuid": model_uuid,
+        },
+        "channel_index": [segment.channel_index, total_channels],
+    }

--- a/src/lightning_owhisper_mlx/segmenter.py
+++ b/src/lightning_owhisper_mlx/segmenter.py
@@ -1,0 +1,98 @@
+"""Audio segmentation helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+import numpy as np
+
+
+@dataclass
+class AudioSegment:
+    """A contiguous block of audio samples."""
+
+    samples: np.ndarray
+    start_time: float
+    end_time: float
+    channel_index: int
+
+
+@dataclass
+class Segmenter:
+    """Simple RMS-based speech segmenter."""
+
+    sample_rate: int
+    redemption_time: float
+    channel_index: int
+    energy_threshold: float = 0.01
+    max_buffer_duration: float = 30.0
+    _buffer: List[np.ndarray] = field(default_factory=list, init=False)
+    _segment_active: bool = field(default=False, init=False)
+    _segment_start: float = field(default=0.0, init=False)
+    _silence_duration: float = field(default=0.0, init=False)
+    _stream_time: float = field(default=0.0, init=False)
+
+    def submit(self, chunk: np.ndarray) -> List[AudioSegment]:
+        """Process a chunk and return completed segments if any."""
+
+        if chunk.ndim != 1:
+            raise ValueError("audio chunk must be one-dimensional")
+
+        duration = len(chunk) / float(self.sample_rate)
+        rms = float(np.sqrt(np.mean(np.square(chunk)))) if len(chunk) else 0.0
+        segments: List[AudioSegment] = []
+
+        if rms >= self.energy_threshold:
+            if not self._segment_active:
+                self._segment_active = True
+                self._segment_start = self._stream_time
+                self._buffer.clear()
+            self._buffer.append(chunk)
+            self._silence_duration = 0.0
+        elif self._segment_active:
+            self._buffer.append(chunk)
+            self._silence_duration += duration
+            if self._silence_duration >= self.redemption_time:
+                segments.append(self._finalize_segment())
+
+        if self._segment_active and self._segment_duration() > self.max_buffer_duration:
+            segments.append(self._finalize_segment())
+
+        self._stream_time += duration
+        return [seg for seg in segments if seg.samples.size > 0]
+
+    def flush(self) -> List[AudioSegment]:
+        """Return the final segment if audio is still buffered."""
+
+        if self._segment_active and self._buffer:
+            return [self._finalize_segment()]
+        return []
+
+    def _segment_duration(self) -> float:
+        total_samples = sum(len(chunk) for chunk in self._buffer)
+        return total_samples / float(self.sample_rate)
+
+    def _finalize_segment(self) -> AudioSegment:
+        if not self._buffer:
+            self._reset()
+            return AudioSegment(np.array([], dtype=np.float32), self._segment_start, self._stream_time, self.channel_index)
+
+        audio = np.concatenate(self._buffer)
+
+        if self._silence_duration > 0:
+            trim_samples = int(self._silence_duration * self.sample_rate)
+            if 0 < trim_samples < audio.size:
+                audio = audio[:-trim_samples]
+
+        end_time = self._segment_start + (audio.size / float(self.sample_rate))
+
+        segment = AudioSegment(audio, self._segment_start, end_time, self.channel_index)
+        self._reset()
+        return segment
+
+    def _reset(self) -> None:
+        self._buffer.clear()
+        self._segment_active = False
+        self._segment_start = self._stream_time
+        self._silence_duration = 0.0

--- a/src/lightning_owhisper_mlx/server.py
+++ b/src/lightning_owhisper_mlx/server.py
@@ -1,0 +1,213 @@
+"""FastAPI application exposing a Deepgram compatible interface."""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from typing import Dict, Iterable, List, Optional
+
+import numpy as np
+from fastapi import Depends, FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect, status
+from fastapi.responses import JSONResponse, PlainTextResponse
+from starlette.websockets import WebSocketState
+
+from .config import AppConfig, ModelConfig
+from .responses import build_transcript_response
+from .segmenter import Segmenter
+from .transcriber import TranscriberService
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Authenticator:
+    """Utility for validating API keys."""
+
+    def __init__(self, api_key: Optional[str]):
+        self.api_key = api_key
+
+    def verify_headers(self, headers: Dict[str, str]) -> None:
+        if self.api_key is None:
+            return
+
+        auth = headers.get("authorization")
+        if not auth:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+
+        token = None
+        if auth.lower().startswith("token "):
+            token = auth[6:].strip()
+        elif auth.lower().startswith("bearer "):
+            token = auth[7:].strip()
+
+        if token != self.api_key:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+
+    def verify_websocket(self, websocket: WebSocket) -> None:
+        if self.api_key is None:
+            return
+        header = websocket.headers.get("authorization")
+        if header is None:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+        token = None
+        header_lower = header.lower()
+        if header_lower.startswith("token "):
+            token = header[6:].strip()
+        elif header_lower.startswith("bearer "):
+            token = header[7:].strip()
+        if token != self.api_key:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+
+
+def create_app(config: AppConfig) -> FastAPI:
+    """Create a configured FastAPI application."""
+
+    authenticator = Authenticator(config.general.api_key)
+    transcriber = TranscriberService()
+
+    app = FastAPI(title="Lightning OWhisper MLX", version="0.1.0")
+
+    async def _auth_dependency(request: Request) -> None:
+        authenticator.verify_headers(request.headers)
+
+    @app.get("/health")
+    async def health(_: None = Depends(_auth_dependency)) -> PlainTextResponse:
+        return PlainTextResponse("OK")
+
+    @app.get("/v1/status")
+    async def status_endpoint(_: None = Depends(_auth_dependency)) -> PlainTextResponse:
+        return PlainTextResponse("", status_code=status.HTTP_204_NO_CONTENT)
+
+    def _serialize_models(models: Iterable[ModelConfig]) -> Dict[str, List[Dict[str, str]]]:
+        return {
+            "object": "list",
+            "data": [
+                {
+                    "id": model.id,
+                    "object": "model",
+                }
+                for model in models
+            ],
+        }
+
+    @app.get("/models")
+    async def list_models(_: None = Depends(_auth_dependency)) -> JSONResponse:
+        return JSONResponse(_serialize_models(config.models))
+
+    @app.get("/v1/models")
+    async def list_models_v1(_: None = Depends(_auth_dependency)) -> JSONResponse:
+        return JSONResponse(_serialize_models(config.models))
+
+    async def handle_websocket(websocket: WebSocket) -> None:
+        try:
+            authenticator.verify_websocket(websocket)
+        except HTTPException:
+            await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+            return
+
+        query = websocket.query_params
+        model_id = query.get("model") or (config.models[0].id if config.models else None)
+        if model_id is None:
+            await websocket.close(code=status.WS_1011_INTERNAL_ERROR)
+            return
+
+        try:
+            model_config = config.require_model(model_id)
+        except KeyError:
+            await websocket.close(code=status.WS_1003_UNSUPPORTED_DATA)
+            return
+
+        try:
+            channels = int(query.get("channels", "1"))
+        except ValueError:
+            channels = 1
+        channels = max(1, min(channels, 2))
+
+        redemption_ms = query.get("redemption_time_ms")
+        try:
+            redemption_time = float(int(redemption_ms) / 1000.0) if redemption_ms else 0.4
+        except ValueError:
+            redemption_time = 0.4
+
+        languages = query.getlist("languages") or []
+        language = languages[0] if languages else query.get("language")
+
+        request_id = uuid.uuid4().hex
+        await websocket.accept(headers=[("dg-request-id", request_id)])
+
+        sample_rate = config.general.sample_rate
+        segmenters = [
+            Segmenter(
+                sample_rate=sample_rate,
+                redemption_time=redemption_time,
+                channel_index=idx,
+                energy_threshold=0.01,
+            )
+            for idx in range(channels)
+        ]
+
+        async def _transcribe_and_send(segment, idx):
+            if segment.samples.size == 0:
+                return
+            result = await transcriber.transcribe(
+                model_config,
+                segment.samples.astype(np.float32),
+                language,
+            )
+            payload = build_transcript_response(
+                result=result,
+                segment=segment,
+                model_name=model_config.model,
+                total_channels=channels,
+                request_id=request_id,
+            )
+            await websocket.send_text(json.dumps(payload))
+
+        try:
+            while True:
+                message = await websocket.receive()
+                if message["type"] == "websocket.disconnect":
+                    break
+
+                if message.get("bytes"):
+                    chunk = np.frombuffer(message["bytes"], dtype=np.int16)
+                    if channels == 1:
+                        float_chunk = chunk.astype(np.float32) / 32768.0
+                        for segment in segmenters[0].submit(float_chunk):
+                            await _transcribe_and_send(segment, 0)
+                    else:
+                        if chunk.size % 2 != 0:
+                            chunk = chunk[:-1]
+                        samples = chunk.reshape(-1, 2)
+                        for idx in range(2):
+                            float_chunk = samples[:, idx].astype(np.float32) / 32768.0
+                            for segment in segmenters[idx].submit(float_chunk):
+                                await _transcribe_and_send(segment, idx)
+                elif message.get("text"):
+                    try:
+                        control = json.loads(message["text"])
+                    except json.JSONDecodeError:
+                        continue
+                    control_type = control.get("type")
+                    if control_type in {"Finalize", "CloseStream"}:
+                        for idx, segmenter in enumerate(segmenters):
+                            for segment in segmenter.flush():
+                                await _transcribe_and_send(segment, idx)
+                        if control_type == "CloseStream":
+                            break
+                if websocket.application_state == WebSocketState.DISCONNECTED:
+                    break
+        except WebSocketDisconnect:
+            pass
+        finally:
+            for idx, segmenter in enumerate(segmenters):
+                for segment in segmenter.flush():
+                    await _transcribe_and_send(segment, idx)
+
+            if websocket.application_state != WebSocketState.DISCONNECTED:
+                await websocket.close()
+
+    app.websocket("/listen")(handle_websocket)
+    app.websocket("/v1/listen")(handle_websocket)
+
+    return app

--- a/src/lightning_owhisper_mlx/transcriber.py
+++ b/src/lightning_owhisper_mlx/transcriber.py
@@ -1,0 +1,103 @@
+"""Utilities for executing lightning-whisper-mlx transcriptions."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+import anyio
+import numpy as np
+
+from .config import ModelConfig
+
+LOGGER = logging.getLogger(__name__)
+
+try:
+    from lightning_whisper_mlx import LightningWhisperMLX  # type: ignore
+except Exception:  # pragma: no cover - handled gracefully at runtime
+    LightningWhisperMLX = None  # type: ignore
+
+
+@dataclass
+class TranscriptionResult:
+    """Container for transcription output."""
+
+    text: str
+    words: list[dict]
+    language: Optional[str]
+
+
+class LightningModelWrapper:
+    """Lazy wrapper around :class:`LightningWhisperMLX`."""
+
+    def __init__(self, config: ModelConfig):
+        self._config = config
+        self._model: Optional[LightningWhisperMLX] = None
+
+    def _ensure_model(self) -> LightningWhisperMLX:
+        if LightningWhisperMLX is None:  # pragma: no cover - depends on runtime env
+            raise RuntimeError(
+                "lightning-whisper-mlx is not installed or not available on this platform"
+            )
+        if self._model is None:
+            LOGGER.info(
+                "loading lightning-whisper-mlx model %s (quant=%s, batch=%s)",
+                self._config.model,
+                self._config.quantization,
+                self._config.batch_size,
+            )
+            self._model = LightningWhisperMLX(
+                model=self._config.model,
+                batch_size=self._config.batch_size,
+                quant=self._config.quantization,
+            )
+        return self._model
+
+    def transcribe(self, audio: np.ndarray, language: Optional[str]) -> TranscriptionResult:
+        model = self._ensure_model()
+        result = model.transcribe(audio_path=audio, language=language)
+        text = result.get("text", "")
+        segments = result.get("segments", []) or []
+
+        words: list[dict] = []
+        for segment in segments:
+            if "words" in segment and segment["words"]:
+                words.extend(segment["words"])
+            else:
+                words.append(
+                    {
+                        "word": segment.get("text", "").strip(),
+                        "start": segment.get("start", 0.0),
+                        "end": segment.get("end", segment.get("start", 0.0)),
+                        "confidence": segment.get("avg_logprob", 0.0),
+                    }
+                )
+
+        language = result.get("language")
+        return TranscriptionResult(text=text, words=words, language=language)
+
+
+class TranscriberCache:
+    """Cache of instantiated :class:`LightningWhisperMLX` models."""
+
+    def __init__(self):
+        self._cache: Dict[str, LightningModelWrapper] = {}
+
+    def get(self, config: ModelConfig) -> LightningModelWrapper:
+        if config.id not in self._cache:
+            self._cache[config.id] = LightningModelWrapper(config)
+        return self._cache[config.id]
+
+
+class TranscriberService:
+    """Service responsible for executing transcriptions asynchronously."""
+
+    def __init__(self, cache: Optional[TranscriberCache] = None):
+        self._cache = cache or TranscriberCache()
+
+    async def transcribe(
+        self, config: ModelConfig, audio: np.ndarray, language: Optional[str]
+    ) -> TranscriptionResult:
+        wrapper = self._cache.get(config)
+        return await anyio.to_thread.run_sync(wrapper.transcribe, audio, language)

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -1,0 +1,30 @@
+from lightning_owhisper_mlx.responses import build_transcript_response
+from lightning_owhisper_mlx.segmenter import AudioSegment
+from lightning_owhisper_mlx.transcriber import TranscriptionResult
+
+import numpy as np
+
+
+def test_build_transcript_response_structure():
+    result = TranscriptionResult(
+        text="Hello world",
+        words=[{"word": "Hello", "start": 0.0, "end": 0.5, "confidence": 0.9}],
+        language="en",
+    )
+    segment = AudioSegment(np.ones(4, dtype=np.float32), start_time=1.0, end_time=1.5, channel_index=0)
+
+    payload = build_transcript_response(
+        result=result,
+        segment=segment,
+        model_name="distil-small.en",
+        total_channels=1,
+        request_id="abc123",
+        model_uuid="uuid",
+    )
+
+    assert payload["type"] == "Results"
+    assert payload["metadata"]["request_id"] == "abc123"
+    alt = payload["channel"]["alternatives"][0]
+    assert alt["transcript"] == "Hello world"
+    assert alt["words"][0]["start"] == 1.0
+    assert alt["words"][0]["confidence"] == 0.9

--- a/tests/test_segmenter.py
+++ b/tests/test_segmenter.py
@@ -1,0 +1,27 @@
+import numpy as np
+
+from lightning_owhisper_mlx.segmenter import Segmenter
+
+
+def test_segmenter_detects_segment():
+    segmenter = Segmenter(sample_rate=4, redemption_time=0.5, channel_index=0, energy_threshold=0.05)
+
+    # Initial silence
+    assert segmenter.submit(np.zeros(4, dtype=np.float32)) == []
+
+    # Speech chunk
+    speech = np.ones(4, dtype=np.float32) * 0.2
+    segments = segmenter.submit(speech)
+    assert segments == []
+
+    # Silence to trigger redemption
+    silence = np.zeros(4, dtype=np.float32)
+    segments = segmenter.submit(silence)
+    assert len(segments) == 1
+    segment = segments[0]
+    assert np.allclose(segment.samples[:4], speech)
+    assert segment.start_time == 1.0  # after initial silence chunk
+    assert segment.end_time > segment.start_time
+
+    # Flush should not return additional segments after reset
+    assert segmenter.flush() == []


### PR DESCRIPTION
## Summary
- add a FastAPI application that mimics Hyprnote's owhisper Deepgram-compatible API while using lightning-whisper-mlx
- implement configuration, transcription, and streaming helpers plus a CLI entrypoint
- document setup and add unit tests for segmentation and response formatting

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cb63daf614832fb8cfe6e08ce6c167