### PR TITLE
Fix import of transcribe_audio

### DIFF
--- a/server/transcriber.py
+++ b/server/transcriber.py
@@ -13,8 +13,9 @@ import numpy as np
 from .config import ServerConfig
 
 try:  # pragma: no cover - optional heavy dependency is imported lazily at runtime
-    from lightning_whisper_mlx import LightningWhisperMLX, transcribe_audio
-except ModuleNotFoundError as exc:  # pragma: no cover
+    from lightning_whisper_mlx import LightningWhisperMLX
+    from lightning_whisper_mlx.transcribe import transcribe_audio
+except (ModuleNotFoundError, ImportError) as exc:  # pragma: no cover
     raise RuntimeError(
         "lightning-whisper-mlx must be installed to run the transcription server"
     ) from exc


### PR DESCRIPTION
## Summary
- fix the optional dependency import so we load transcribe_audio from the correct module and surface a clear runtime error when it is missing

## Testing
- no automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d490158e94832f865fd9abe1286579