### PR TITLE
Add Deepgram-compatible status endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ and exposes both REST and WebSocket streaming endpoints.
 
 ## Features
 
+- `GET /v1/status`: Lightweight status and configuration check for health probes
+  or client readiness verification.
 - `POST /v1/listen`: Deepgram-style single-shot transcription of audio files.
 - `WS /v1/listen`: Real-time or near-real-time chunked streaming transcription with
   Deepgram-compatible control messages (`start`, `stop`, `ping`, etc.).

--- a/server/app.py
+++ b/server/app.py
@@ -32,6 +32,16 @@ def create_app(config: ServerConfig | None = None) -> FastAPI:
     async def health() -> dict[str, str]:
         return {"status": "ok"}
 
+    @app.get("/v1/status")
+    async def status() -> dict[str, Any]:
+        return {
+            "status": "ok",
+            "model": cfg.model,
+            "quantization": cfg.quantization,
+            "sample_rate": cfg.sample_rate,
+            "version": app.version,
+        }
+
     @app.post("/v1/listen")
     async def listen(
         file: UploadFile = File(...),


### PR DESCRIPTION
## Summary
- add a /v1/status route that returns server status and configuration metadata
- document the new endpoint in the feature list

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d491f4a8c4832f9525e5cda9c3959f