### PR TITLE
Add Deepgram-compatible lightning whisper server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,96 @@
+# Lightning Whisper Deepgram Server
+
+This repository provides a drop-in replacement for Deepgram's streaming WebSocket API powered by [lightning-whisper-mlx](https://github.com/Lightning-AI/lightning-whisper-mlx). The server accepts Deepgram-compatible WebSocket messages, streams PCM16 audio, and responds with metadata and transcription results that follow Deepgram's schema.
+
+## Features
+
+- ⚡️ **Lightning Whisper backend** – Uses the Apple MLX-optimised Whisper models for rapid transcription.
+- 🔁 **Real-time streaming** – Handles WebSocket media frames, incremental transcription, and utterance finalisation.
+- 🔄 **Deepgram compatibility** – Supports `ListenV1Media`, `ListenV1Finalize`, keep-alives, metadata, and result payloads matching Deepgram's schema.
+- 🔊 **Audio preprocessing** – Incremental PCM16 chunking, optional resampling, and rudimentary speech detection.
+- 🧪 **Test utilities** – Scripts for collecting sample audio, simulating live streaming, and performing smoke tests.
+
+## Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+The `lightning-whisper-mlx` package will download model weights on first use. For Apple Silicon the default MLX backend is used automatically.
+
+## Running the server
+
+```bash
+uvicorn src.server:app --host 0.0.0.0 --port 9000
+```
+
+### Environment variables
+
+Configuration options can be overridden via environment variables (prefixed with `LIGHTNING_WHISPER_`):
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `LIGHTNING_WHISPER_MODEL` | Whisper model name (e.g. `small`, `medium`, `distil-small.en`) | `small` |
+| `LIGHTNING_WHISPER_BATCH_SIZE` | Batch size for inference | `12` |
+| `LIGHTNING_WHISPER_QUANT` | Optional quantisation (`4bit`/`8bit`) | unset |
+| `LIGHTNING_WHISPER_CHUNK_SIZE` | Length of buffered audio (seconds) before transcription | `5.0` |
+| `LIGHTNING_WHISPER_SAMPLE_RATE` | Expected input sample rate | `16000` |
+| `LIGHTNING_WHISPER_LANGUAGE` | Default language hint | unset |
+| `LIGHTNING_WHISPER_ENABLE_WORD_TIMESTAMPS` | Approximate word timing output (`true`/`false`) | `false` |
+
+## API Usage
+
+1. **Connect** to `ws://<host>:<port>/v1/listen`.
+2. **Send a configure message** (optional) matching Deepgram's schema, e.g.:
+   ```json
+   {"type": "ListenV1Configure", "sample_rate": 16000, "channels": 1}
+   ```
+3. **Stream PCM16 audio** as binary WebSocket frames (`ListenV1Media`).
+4. **Finalize** the stream by sending `{"type": "ListenV1Finalize"}`.
+5. Optionally send keep-alives `{"type": "ListenV1KeepAlive"}`.
+6. Close the connection with `{"type": "ListenV1CloseStream"}` or by closing the socket.
+
+Responses include metadata, speech-start notifications, incremental results, and a final `utterance_end` message mirroring Deepgram's API.
+
+## Testing utilities
+
+- `test_audio_collector.py` – Download YouTube audio and split into chunks.
+- `test_realtime_simulation.py` – Simulate streaming a WAV file to the server.
+- `test_websocket_client.py` – Generate a synthetic sine tone and observe the server's responses.
+- `test_integration.py` – Basic smoke tests for the core modules.
+
+Run the scripted checks with:
+
+```bash
+python test_integration.py
+```
+
+or simulate a real stream:
+
+```bash
+python test_realtime_simulation.py sample.wav --chunk-duration 1.5
+```
+
+## Project structure
+
+```
+src/
+  audio_processor.py       # Incremental PCM16 chunking
+  config.py                # Environment-driven configuration
+  deepgram_adapter.py      # Deepgram schema conversion helpers
+  models.py                # Pydantic response models
+  transcription_service.py # lightning-whisper-mlx integration
+  server.py                # FastAPI WebSocket server
+```
+
+## Notes
+
+- Word timings are approximated from segment timings when the model does not provide token-level timestamps.
+- The first transcription request downloads the model weights to `./mlx_models/<model-name>`.
+- For production deployments consider running behind a process manager (e.g. `systemd`, `supervisord`) and enabling TLS termination.
+
+## License
+
+This repository aggregates open-source components; consult upstream projects for their respective licenses.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "lightning-owhisper-mlx"
+version = "0.1.0"
+description = "Deepgram-compatible streaming server powered by lightning-whisper-mlx"
+readme = "README.md"
+authors = [{name = "OpenAI Assistant"}]
+requires-python = ">=3.10"
+dependencies = [
+    "fastapi==0.118.0",
+    "websockets==15.0.1",
+    "uvicorn==0.24.0",
+    "pydantic==2.5.0",
+    "numpy>=1.24,<3.0",
+    "scipy>=1.10,<2.0",
+    "lightning-whisper-mlx",
+    "python-multipart==0.0.6",
+    "yt-dlp==2023.12.30",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=7.4"]
+
+[tool.setuptools.package-dir]
+"" = "src"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+fastapi==0.118.0
+websockets==15.0.1
+uvicorn==0.24.0
+pydantic==2.5.0
+numpy>=1.24,<3.0
+scipy>=1.10,<2.0
+lightning-whisper-mlx
+python-multipart==0.0.6
+yt-dlp==2023.12.30

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,10 @@
+"""Lightning Whisper Deepgram-compatible server package."""
+
+__all__ = [
+    "config",
+    "models",
+    "audio_processor",
+    "deepgram_adapter",
+    "transcription_service",
+    "server",
+]

--- a/src/audio_processor.py
+++ b/src/audio_processor.py
@@ -1,0 +1,89 @@
+"""Audio buffering and preprocessing utilities."""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import List, Optional
+
+import numpy as np
+
+
+@dataclass
+class AudioChunk:
+    """Represents a chunk of audio ready for transcription."""
+
+    samples: np.ndarray
+    start_time: float
+    end_time: float
+    sample_rate: int
+
+    @property
+    def duration(self) -> float:
+        """Return the duration of the chunk in seconds."""
+
+        return float(len(self.samples) / self.sample_rate)
+
+
+class AudioProcessor:
+    """Incrementally consumes PCM16 audio bytes and yields uniform chunks."""
+
+    def __init__(
+        self,
+        *,
+        sample_rate: int,
+        chunk_size: float,
+        channels: int = 1,
+    ) -> None:
+        self.sample_rate = sample_rate
+        self.chunk_size = chunk_size
+        self.channels = channels
+        self._buffer = bytearray()
+        self._processed_samples = 0
+        self._bytes_per_sample = 2 * channels  # pcm16
+        self._chunk_bytes = int(math.ceil(self.chunk_size * self.sample_rate * self._bytes_per_sample))
+
+    def append(self, data: bytes) -> List[AudioChunk]:
+        """Append PCM16 bytes to the processor and return ready chunks."""
+
+        if not data:
+            return []
+
+        self._buffer.extend(data)
+        return self._consume_ready_chunks()
+
+    def flush(self) -> Optional[AudioChunk]:
+        """Flush any remaining samples into a final chunk."""
+
+        if not self._buffer:
+            return None
+
+        chunk = self._buffer[:]
+        self._buffer.clear()
+        return self._as_chunk(chunk)
+
+    def _consume_ready_chunks(self) -> List[AudioChunk]:
+        chunks: List[AudioChunk] = []
+        while len(self._buffer) >= self._chunk_bytes:
+            raw = self._buffer[: self._chunk_bytes]
+            del self._buffer[: self._chunk_bytes]
+            chunks.append(self._as_chunk(raw))
+        return chunks
+
+    def _as_chunk(self, raw: bytes) -> AudioChunk:
+        """Convert raw PCM16 bytes into an :class:`AudioChunk`."""
+
+        if self.channels == 1:
+            samples = np.frombuffer(raw, dtype=np.int16).astype(np.float32)
+        else:
+            multi = np.frombuffer(raw, dtype=np.int16).astype(np.float32)
+            samples = multi.reshape(-1, self.channels).mean(axis=1)
+
+        samples /= np.float32(32768.0)
+        sample_count = len(samples)
+        start_time = self._processed_samples / self.sample_rate
+        end_time = (self._processed_samples + sample_count) / self.sample_rate
+        self._processed_samples += sample_count
+        return AudioChunk(samples=samples, start_time=start_time, end_time=end_time, sample_rate=self.sample_rate)
+
+
+__all__ = ["AudioProcessor", "AudioChunk"]

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,61 @@
+"""Configuration utilities for the Lightning Whisper Deepgram-compatible server."""
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Optional
+
+from pydantic import BaseSettings, Field, validator
+
+
+class Config(BaseSettings):
+    """Application configuration loaded from environment variables."""
+
+    host: str = Field("0.0.0.0", description="Host interface for the server")
+    port: int = Field(9000, description="Port for the server to bind to")
+    model: str = Field("small", description="Name of the lightning-whisper-mlx model to load")
+    batch_size: int = Field(12, description="Batch size used by the transcription engine")
+    quant: Optional[str] = Field(
+        None,
+        description="Optional quantization level to request from the whisper model (4bit or 8bit)",
+    )
+    chunk_size: float = Field(
+        5.0,
+        description="Duration, in seconds, of audio buffered before triggering a transcription run.",
+    )
+    sample_rate: int = Field(
+        16000,
+        description="Expected input sample rate of the audio stream. Incoming audio will be resampled if necessary.",
+    )
+    language: Optional[str] = Field(
+        None,
+        description="Optional language hint forwarded to the transcription engine.",
+    )
+    enable_word_timestamps: bool = Field(
+        False,
+        description="When true, attempt to approximate word-level timestamps even when the model does not expose them.",
+    )
+
+    class Config:
+        env_prefix = "LIGHTNING_WHISPER_"
+        env_file = ".env"
+
+    @validator("quant")
+    def _validate_quant(cls, value: Optional[str]) -> Optional[str]:  # noqa: D401 - short docstring
+        """Ensure the quantization value is valid."""
+
+        if value is None:
+            return value
+        normalized = value.lower()
+        if normalized not in {"4bit", "8bit"}:
+            raise ValueError("quant must be either '4bit' or '8bit'")
+        return normalized
+
+
+@lru_cache()
+def get_config() -> Config:
+    """Return a cached configuration instance."""
+
+    return Config()
+
+
+__all__ = ["Config", "get_config"]

--- a/src/deepgram_adapter.py
+++ b/src/deepgram_adapter.py
@@ -1,0 +1,91 @@
+"""Conversion helpers that transform internal results into Deepgram-compatible payloads."""
+from __future__ import annotations
+
+import platform
+from dataclasses import dataclass, field
+from typing import List
+
+from .models import (
+    Alternative,
+    ChannelResult,
+    ListenV1Metadata,
+    ListenV1Results,
+    ListenV1SpeechStarted,
+    ListenV1UtteranceEnd,
+    Metadata,
+    ModelInfo,
+    WordTiming,
+)
+from .transcription_service import TranscriptionChunkResult, Word
+
+
+@dataclass
+class StreamState:
+    """Accumulates the transcript and word history for a connection."""
+
+    transcript: str = ""
+    words: List[Word] = field(default_factory=list)
+
+    def append(self, result: TranscriptionChunkResult) -> None:
+        if result.text:
+            if self.transcript:
+                self.transcript = f"{self.transcript} {result.text}".strip()
+            else:
+                self.transcript = result.text
+        if result.words:
+            self.words.extend(result.words)
+
+    def reset(self) -> None:
+        self.transcript = ""
+        self.words.clear()
+
+
+class DeepgramAdapter:
+    """Creates Deepgram-compatible payloads from transcription results."""
+
+    def __init__(self, *, request_id: str, model_name: str, model_version: str) -> None:
+        self.request_id = request_id
+        self.model_name = model_name
+        self.model_version = model_version
+        self.metadata = Metadata(
+            request_id=request_id,
+            model_info=ModelInfo(name=model_name, version=model_version, arch=platform.machine()),
+        )
+
+    def build_metadata_message(self) -> ListenV1Metadata:
+        return ListenV1Metadata(metadata=self.metadata)
+
+    def build_results_message(
+        self,
+        *,
+        chunk_result: TranscriptionChunkResult,
+        state: StreamState,
+        is_final: bool,
+    ) -> ListenV1Results:
+        transcript_text = state.transcript or chunk_result.text
+        word_timings = [self._to_word_timing(word) for word in state.words] if state.words else [
+            self._to_word_timing(word) for word in chunk_result.words
+        ]
+
+        alternative = Alternative(transcript=transcript_text, confidence=None, words=word_timings)
+        channel = ChannelResult(alternatives=[alternative])
+        return ListenV1Results(
+            duration=chunk_result.end - chunk_result.start,
+            start=chunk_result.start,
+            is_final=is_final,
+            speech_final=is_final,
+            channel=channel,
+            metadata=self.metadata,
+        )
+
+    def build_speech_started(self) -> ListenV1SpeechStarted:
+        return ListenV1SpeechStarted(metadata=self.metadata)
+
+    def build_utterance_end(self) -> ListenV1UtteranceEnd:
+        return ListenV1UtteranceEnd(metadata=self.metadata)
+
+    def _to_word_timing(self, word: Word) -> WordTiming:
+        return WordTiming(word=word.word, start=word.start, end=word.end, confidence=word.confidence)
+
+
+__all__ = ["DeepgramAdapter", "StreamState"]

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,122 @@
+"""Pydantic models representing Deepgram-compatible request and response payloads."""
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class ModelInfo(BaseModel):
+    """Description of the transcription model in Deepgram-compatible format."""
+
+    name: str
+    version: str
+    arch: str
+
+
+class Metadata(BaseModel):
+    """Metadata returned in each Deepgram result message."""
+
+    request_id: str = Field(..., alias="request_id")
+    model_info: ModelInfo
+
+
+class WordTiming(BaseModel):
+    """Represents the start and end offsets of a recognised word."""
+
+    word: str
+    start: float
+    end: float
+    confidence: Optional[float] = None
+
+
+class Alternative(BaseModel):
+    """A transcription alternative for a given channel."""
+
+    transcript: str
+    confidence: Optional[float] = None
+    words: List[WordTiming] = Field(default_factory=list)
+
+
+class ChannelResult(BaseModel):
+    """Container for the alternatives detected within a channel."""
+
+    alternatives: List[Alternative] = Field(default_factory=list)
+
+
+class ListenV1Results(BaseModel):
+    """Primary result payload returned to clients following Deepgram's schema."""
+
+    type: str = Field("results", const=True)
+    channel_index: List[int] = Field(default_factory=lambda: [0])
+    duration: float
+    start: float
+    is_final: bool
+    speech_final: bool
+    channel: ChannelResult
+    metadata: Metadata
+
+
+class ListenV1Metadata(BaseModel):
+    """Initial metadata message sent when the connection is established."""
+
+    type: str = Field("metadata", const=True)
+    metadata: Metadata
+
+
+class ListenV1UtteranceEnd(BaseModel):
+    """Message emitted when the server detects the end of an utterance."""
+
+    type: str = Field("utterance_end", const=True)
+    channel_index: List[int] = Field(default_factory=lambda: [0])
+    metadata: Metadata
+
+
+class ListenV1SpeechStarted(BaseModel):
+    """Notification triggered when incoming audio contains speech-like content."""
+
+    type: str = Field("speech_started", const=True)
+    channel_index: List[int] = Field(default_factory=lambda: [0])
+    metadata: Metadata
+
+
+class InboundConfiguration(BaseModel):
+    """Client configuration message."""
+
+    type: str
+    sample_rate: Optional[int] = None
+    encoding: Optional[str] = None
+    channels: Optional[int] = None
+    language: Optional[str] = None
+
+
+class InboundFinalize(BaseModel):
+    """Finalise request payload."""
+
+    type: str
+
+
+class InboundKeepAlive(BaseModel):
+    """Keep alive message."""
+
+    type: str
+
+
+InboundMessage = InboundConfiguration | InboundFinalize | InboundKeepAlive
+
+
+__all__ = [
+    "Alternative",
+    "ChannelResult",
+    "InboundConfiguration",
+    "InboundFinalize",
+    "InboundKeepAlive",
+    "InboundMessage",
+    "ListenV1Metadata",
+    "ListenV1Results",
+    "ListenV1SpeechStarted",
+    "ListenV1UtteranceEnd",
+    "Metadata",
+    "ModelInfo",
+    "WordTiming",
+]

--- a/src/server.py
+++ b/src/server.py
@@ -1,0 +1,211 @@
+"""FastAPI based WebSocket server that mimics the Deepgram streaming API."""
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from typing import Any, Dict, Optional
+
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.responses import JSONResponse
+from starlette.websockets import WebSocketState
+
+from .audio_processor import AudioProcessor
+from .config import get_config
+from .deepgram_adapter import DeepgramAdapter, StreamState
+from .transcription_service import TranscriptionChunkResult, TranscriptionService
+
+LOGGER = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+app = FastAPI(title="Lightning Whisper Deepgram Server")
+
+_config = get_config()
+_service = TranscriptionService(
+    model_name=_config.model,
+    batch_size=_config.batch_size,
+    quant=_config.quant,
+    language=_config.language,
+    enable_word_timestamps=_config.enable_word_timestamps,
+)
+
+
+@app.get("/health", response_class=JSONResponse)
+async def health() -> Dict[str, str]:
+    """Simple health check endpoint."""
+
+    return {"status": "ok", "model": _config.model}
+
+
+@app.websocket("/v1/listen")
+async def websocket_endpoint(websocket: WebSocket) -> None:
+    await websocket.accept()
+    request_id = str(uuid.uuid4())
+    adapter = DeepgramAdapter(
+        request_id=request_id,
+        model_name=_config.model,
+        model_version=_service.model_version,
+    )
+    state = StreamState()
+    channels = 1
+    sample_rate = _config.sample_rate
+    language_override: Optional[str] = _config.language
+    processor = AudioProcessor(sample_rate=sample_rate, chunk_size=_config.chunk_size, channels=channels)
+    speech_started = False
+    last_result: Optional[TranscriptionChunkResult] = None
+
+    await websocket.send_json(adapter.build_metadata_message().model_dump(by_alias=True))
+
+    try:
+        while True:
+            message = await websocket.receive()
+            if "bytes" in message and message["bytes"] is not None:
+                for chunk in processor.append(message["bytes"]):
+                    try:
+                        result = await _service.transcribe_chunk(
+                            chunk.samples,
+                            start=chunk.start_time,
+                            end=chunk.end_time,
+                            sample_rate=chunk.sample_rate,
+                            language=language_override,
+                        )
+                    except RuntimeError as exc:
+                        await websocket.send_json({"type": "error", "message": str(exc)})
+                        LOGGER.error("Transcription error: %s", exc)
+                        return
+                    if not result.is_speech and not result.text:
+                        continue
+                    if result.is_speech and not speech_started:
+                        await websocket.send_json(adapter.build_speech_started().model_dump(by_alias=True))
+                        speech_started = True
+                    state.append(result)
+                    last_result = result
+                    payload = adapter.build_results_message(
+                        chunk_result=result,
+                        state=state,
+                        is_final=False,
+                    )
+                    await websocket.send_json(payload.model_dump(by_alias=True))
+            elif "text" in message and message["text"] is not None:
+                try:
+                    payload = json.loads(message["text"])
+                except json.JSONDecodeError:
+                    LOGGER.warning("Received invalid JSON payload: %s", message["text"])
+                    continue
+
+                message_type = _classify_message_type(payload)
+                if message_type == "configure":
+                    sample_rate, channels, language_override, processor = _apply_configuration(
+                        payload,
+                        sample_rate,
+                        channels,
+                        language_override,
+                    )
+                    state.reset()
+                    speech_started = False
+                    last_result = None
+                    await websocket.send_json({"type": "configured", "request_id": request_id})
+                elif message_type == "finalize":
+                    final_chunk = processor.flush()
+                    if final_chunk is not None:
+                        try:
+                            result = await _service.transcribe_chunk(
+                                final_chunk.samples,
+                                start=final_chunk.start_time,
+                                end=final_chunk.end_time,
+                                sample_rate=final_chunk.sample_rate,
+                                language=language_override,
+                            )
+                        except RuntimeError as exc:
+                            await websocket.send_json({"type": "error", "message": str(exc)})
+                            LOGGER.error("Transcription error: %s", exc)
+                            break
+                        if result.is_speech and not speech_started:
+                            await websocket.send_json(adapter.build_speech_started().model_dump(by_alias=True))
+                            speech_started = True
+                        if result.text or result.words:
+                            state.append(result)
+                            last_result = result
+                            payload = adapter.build_results_message(
+                                chunk_result=result,
+                                state=state,
+                                is_final=True,
+                            )
+                            await websocket.send_json(payload.model_dump(by_alias=True))
+                    elif last_result is not None:
+                        payload = adapter.build_results_message(
+                            chunk_result=last_result,
+                            state=state,
+                            is_final=True,
+                        )
+                        await websocket.send_json(payload.model_dump(by_alias=True))
+                    await websocket.send_json(adapter.build_utterance_end().model_dump(by_alias=True))
+                    state.reset()
+                    speech_started = False
+                    last_result = None
+                    processor = AudioProcessor(sample_rate=sample_rate, chunk_size=_config.chunk_size, channels=channels)
+                elif message_type == "close":
+                    await websocket.close()
+                    break
+                elif message_type == "keepalive":
+                    await websocket.send_json({"type": "keepalive"})
+                else:
+                    LOGGER.debug("Ignoring message: %s", payload)
+            else:
+                LOGGER.debug("Unhandled message type: %s", message)
+    except WebSocketDisconnect:
+        LOGGER.info("Client disconnected: %s", request_id)
+    except Exception as exc:  # pragma: no cover - best effort error handling
+        LOGGER.exception("WebSocket error: %s", exc)
+        if websocket.application_state != WebSocketState.DISCONNECTED:
+            await websocket.close(code=1011, reason=str(exc))
+    finally:
+        if websocket.application_state != WebSocketState.DISCONNECTED:
+            await websocket.close()
+
+
+def _classify_message_type(payload: Dict[str, Any]) -> str:
+    message_type = str(payload.get("type", "")).lower()
+    if "final" in message_type:
+        return "finalize"
+    if "close" in message_type:
+        return "close"
+    if "keep" in message_type:
+        return "keepalive"
+    if "config" in message_type or "start" in message_type:
+        return "configure"
+    return "unknown"
+
+
+def _apply_configuration(
+    payload: Dict[str, Any],
+    current_sample_rate: int,
+    current_channels: int,
+    current_language: Optional[str],
+) -> tuple[int, int, Optional[str], AudioProcessor]:
+    config = payload.get("config", {})
+    sample_rate = payload.get("sample_rate") or config.get("sample_rate")
+    channels = payload.get("channels") or config.get("channels")
+    language = payload.get("language") or config.get("language")
+
+    new_sample_rate = current_sample_rate
+    new_channels = current_channels
+    new_language = current_language
+
+    if sample_rate:
+        new_sample_rate = int(sample_rate)
+    if channels:
+        new_channels = int(channels)
+    if language:
+        new_language = str(language)
+
+    processor = AudioProcessor(
+        sample_rate=new_sample_rate,
+        chunk_size=_config.chunk_size,
+        channels=new_channels,
+    )
+
+    return new_sample_rate, new_channels, new_language, processor
+
+
+__all__ = ["app"]

--- a/src/transcription_service.py
+++ b/src/transcription_service.py
@@ -1,0 +1,234 @@
+"""Integration with lightning-whisper-mlx for audio transcription."""
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
+import threading
+
+import numpy as np
+
+try:  # pragma: no cover - optional dependency runtime import
+    from importlib.metadata import PackageNotFoundError, version
+except ModuleNotFoundError:  # pragma: no cover
+    PackageNotFoundError = Exception  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional dependency runtime import
+    from lightning_whisper_mlx import LightningWhisperMLX
+    from lightning_whisper_mlx.audio import HOP_LENGTH, SAMPLE_RATE as MODEL_SAMPLE_RATE
+    from lightning_whisper_mlx.transcribe import transcribe_audio
+except Exception:  # pragma: no cover - handled gracefully
+    LightningWhisperMLX = None  # type: ignore[assignment]
+    transcribe_audio = None  # type: ignore[assignment]
+    HOP_LENGTH = 160
+    MODEL_SAMPLE_RATE = 16000
+
+try:  # pragma: no cover - optional dependency
+    from scipy.signal import resample_poly
+except Exception:  # pragma: no cover
+    resample_poly = None  # type: ignore[assignment]
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class Word:
+    """Internal representation of recognised words."""
+
+    word: str
+    start: float
+    end: float
+    confidence: Optional[float] = None
+
+
+@dataclass
+class TranscriptionChunkResult:
+    """Structured output from the transcription service."""
+
+    text: str
+    start: float
+    end: float
+    words: List[Word]
+    language: Optional[str]
+    is_speech: bool
+
+
+class TranscriptionService:
+    """Service that wraps lightning-whisper-mlx for audio transcription."""
+
+    def __init__(
+        self,
+        *,
+        model_name: str,
+        batch_size: int,
+        quant: Optional[str],
+        language: Optional[str],
+        enable_word_timestamps: bool,
+    ) -> None:
+        self.model_name = model_name
+        self.batch_size = batch_size
+        self.quant = quant
+        self.language = language
+        self.enable_word_timestamps = enable_word_timestamps
+        self._model_wrapper: Optional[LightningWhisperMLX] = None
+        self._model_path: Optional[Path] = None
+        self._load_lock = threading.Lock()
+
+    @property
+    def model_version(self) -> str:
+        """Return the installed lightning-whisper-mlx version if available."""
+
+        try:
+            return version("lightning-whisper-mlx")
+        except PackageNotFoundError:  # pragma: no cover - optional dependency
+            return "unknown"
+
+    async def transcribe_chunk(
+        self,
+        chunk: np.ndarray,
+        *,
+        start: float,
+        end: float,
+        sample_rate: int,
+        language: Optional[str] = None,
+    ) -> TranscriptionChunkResult:
+        """Transcribe an audio chunk asynchronously."""
+
+        return await asyncio.to_thread(
+            self._transcribe_chunk_sync,
+            chunk,
+            start,
+            end,
+            sample_rate,
+            language,
+        )
+
+    def _transcribe_chunk_sync(
+        self,
+        samples: np.ndarray,
+        start: float,
+        end: float,
+        sample_rate: int,
+        language: Optional[str],
+    ) -> TranscriptionChunkResult:
+        if samples.size == 0:
+            return TranscriptionChunkResult(
+                text="",
+                start=start,
+                end=end,
+                words=[],
+                language=self.language,
+                is_speech=False,
+            )
+
+        waveform = self._resample(samples, source_rate=sample_rate)
+        energy = float(np.sqrt(np.mean(np.square(waveform))))
+        speech_detected = bool(waveform.size and energy > 0.0005)
+
+        model_result = self._run_inference(waveform, language_override=language)
+
+        text = model_result.get("text", "").strip() if isinstance(model_result, dict) else ""
+        detected_language = model_result.get("language") if isinstance(model_result, dict) else None
+        segments = model_result.get("segments", []) if isinstance(model_result, dict) else []
+
+        words = self._segments_to_words(segments, start_offset=start)
+
+        if self.enable_word_timestamps and not words and text:
+            words = self._approximate_words(text, start, end)
+
+        if not text and words:
+            text = " ".join(word.word for word in words)
+
+        return TranscriptionChunkResult(
+            text=text,
+            start=start,
+            end=end,
+            words=words,
+            language=detected_language or language or self.language,
+            is_speech=speech_detected or bool(text),
+        )
+
+    def _resample(self, samples: np.ndarray, *, source_rate: int) -> np.ndarray:
+        """Resample incoming audio to the model's expected sample rate."""
+
+        if source_rate == MODEL_SAMPLE_RATE:
+            return samples.astype(np.float32)
+
+        if resample_poly is None:
+            LOGGER.warning(
+                "scipy is not available; falling back to naive interpolation for resampling from %s to %s",
+                source_rate,
+                MODEL_SAMPLE_RATE,
+            )
+            duration = samples.shape[0] / float(source_rate)
+            target_length = int(duration * MODEL_SAMPLE_RATE)
+            if target_length <= 0:
+                return samples.astype(np.float32)
+            x_old = np.linspace(0.0, duration, num=samples.shape[0], endpoint=False)
+            x_new = np.linspace(0.0, duration, num=target_length, endpoint=False)
+            return np.interp(x_new, x_old, samples).astype(np.float32)
+
+        gcd = math.gcd(source_rate, MODEL_SAMPLE_RATE)
+        up = MODEL_SAMPLE_RATE // gcd
+        down = source_rate // gcd
+        resampled = resample_poly(samples, up, down)
+        return resampled.astype(np.float32)
+
+    def _run_inference(self, waveform: np.ndarray, *, language_override: Optional[str]) -> dict:
+        if LightningWhisperMLX is None or transcribe_audio is None:
+            raise RuntimeError(
+                "lightning-whisper-mlx is not installed. Please install the package to enable transcription."
+            )
+
+        if self._model_wrapper is None:
+            with self._load_lock:
+                if self._model_wrapper is None:
+                    self._model_wrapper = LightningWhisperMLX(self.model_name, batch_size=self.batch_size, quant=self.quant)
+                    model_dir = Path("./mlx_models") / getattr(self._model_wrapper, "name", self.model_name)
+                    self._model_path = model_dir
+
+        assert self._model_path is not None  # for type checkers
+
+        kwargs = {
+            "audio": waveform,
+            "path_or_hf_repo": str(self._model_path),
+            "batch_size": self.batch_size,
+        }
+        chosen_language = language_override or self.language
+        if chosen_language:
+            kwargs["language"] = chosen_language
+
+        return transcribe_audio(**kwargs)
+
+    def _segments_to_words(self, segments: List[list], *, start_offset: float) -> List[Word]:
+        words: List[Word] = []
+        for segment in segments:
+            if not isinstance(segment, (list, tuple)) or len(segment) < 3:
+                continue
+            start_seek, end_seek, text = segment[0], segment[1], segment[2]
+            if not text:
+                continue
+            start = start_offset + float(start_seek * HOP_LENGTH / MODEL_SAMPLE_RATE)
+            end = start_offset + float(end_seek * HOP_LENGTH / MODEL_SAMPLE_RATE)
+            words.extend(self._approximate_words(str(text), start, end))
+        return words
+
+    def _approximate_words(self, text: str, start: float, end: float) -> List[Word]:
+        tokens = [token for token in text.split() if token]
+        if not tokens:
+            return []
+        duration = max(end - start, 0.0)
+        interval = duration / max(len(tokens), 1)
+        words: List[Word] = []
+        for index, token in enumerate(tokens):
+            word_start = start + index * interval
+            word_end = word_start + interval
+            words.append(Word(word=token, start=word_start, end=word_end if interval else word_start))
+        return words
+
+
+__all__ = ["TranscriptionService", "TranscriptionChunkResult", "Word"]

--- a/test_audio_collector.py
+++ b/test_audio_collector.py
@@ -1,0 +1,89 @@
+"""Utility script to download audio samples for integration testing."""
+from __future__ import annotations
+
+import argparse
+import math
+from pathlib import Path
+import wave
+
+from yt_dlp import YoutubeDL
+
+
+def download_youtube_audio(url: str, destination: Path) -> Path:
+    """Download a video's audio track and convert it to WAV."""
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    ydl_opts = {
+        "format": "bestaudio/best",
+        "outtmpl": str(destination.with_suffix("")),
+        "postprocessors": [
+            {
+                "key": "FFmpegExtractAudio",
+                "preferredcodec": "wav",
+                "preferredquality": "192",
+            }
+        ],
+    }
+    with YoutubeDL(ydl_opts) as ydl:
+        info = ydl.extract_info(url, download=True)
+        filename = ydl.prepare_filename(info)
+    output = Path(filename).with_suffix(".wav")
+    if output != destination:
+        output.rename(destination)
+        output = destination
+    return output
+
+
+def chunk_audio_file(source: Path, chunk_duration: float, target_dir: Path) -> None:
+    """Split a WAV file into equally sized chunks."""
+
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    with wave.open(str(source), "rb") as wav_in:
+        frame_rate = wav_in.getframerate()
+        channels = wav_in.getnchannels()
+        sampwidth = wav_in.getsampwidth()
+        frames_per_chunk = int(frame_rate * chunk_duration)
+        total_frames = wav_in.getnframes()
+        chunk_count = math.ceil(total_frames / frames_per_chunk)
+
+        for index in range(chunk_count):
+            frames = wav_in.readframes(frames_per_chunk)
+            if not frames:
+                break
+            chunk_path = target_dir / f"chunk_{index:04d}.wav"
+            with wave.open(str(chunk_path), "wb") as wav_out:
+                wav_out.setnchannels(channels)
+                wav_out.setsampwidth(sampwidth)
+                wav_out.setframerate(frame_rate)
+                wav_out.writeframes(frames)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Download and chunk audio for testing.")
+    parser.add_argument("url", help="YouTube URL to download")
+    parser.add_argument("destination", type=Path, help="Destination WAV file path")
+    parser.add_argument(
+        "--chunk-duration",
+        type=float,
+        default=15.0,
+        help="Chunk duration in seconds for optional splitting",
+    )
+    parser.add_argument(
+        "--chunks-dir",
+        type=Path,
+        default=None,
+        help="Optional directory to store chunked audio files",
+    )
+    args = parser.parse_args()
+
+    wav_path = download_youtube_audio(args.url, args.destination)
+    print(f"Downloaded audio to {wav_path}")
+
+    if args.chunks_dir is not None:
+        chunk_audio_file(wav_path, args.chunk_duration, args.chunks_dir)
+        print(f"Chunks written to {args.chunks_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test_integration.py
+++ b/test_integration.py
@@ -1,0 +1,36 @@
+"""Lightweight integration checks for core components."""
+from __future__ import annotations
+
+import numpy as np
+
+from src.audio_processor import AudioProcessor
+from src.deepgram_adapter import DeepgramAdapter, StreamState
+from src.transcription_service import TranscriptionChunkResult, Word
+
+
+def run_basic_checks() -> None:
+    processor = AudioProcessor(sample_rate=16000, chunk_size=0.5)
+    samples = (np.sin(2 * np.pi * 440 * np.linspace(0, 1, 16000, endpoint=False)) * 32767).astype(np.int16)
+    payload = samples.tobytes()
+    chunks = processor.append(payload)
+    assert chunks, "Expected at least one chunk from the audio processor"
+
+    result = TranscriptionChunkResult(
+        text="hello world",
+        start=0.0,
+        end=0.5,
+        words=[Word(word="hello", start=0.0, end=0.25), Word(word="world", start=0.25, end=0.5)],
+        language="en",
+        is_speech=True,
+    )
+    state = StreamState()
+    state.append(result)
+    adapter = DeepgramAdapter(request_id="test", model_name="tiny", model_version="0.0.0")
+    payload = adapter.build_results_message(chunk_result=result, state=state, is_final=True)
+    assert payload.type == "results"
+    assert payload.channel.alternatives[0].transcript == "hello world"
+
+
+if __name__ == "__main__":
+    run_basic_checks()
+    print("Integration checks passed.")

--- a/test_realtime_simulation.py
+++ b/test_realtime_simulation.py
@@ -1,0 +1,81 @@
+"""Simulate a client streaming audio to the local Deepgram-compatible server."""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from pathlib import Path
+import wave
+
+import websockets
+
+
+async def simulate_stream(
+    audio_path: Path,
+    *,
+    uri: str,
+    chunk_duration: float,
+    language: str | None = None,
+) -> None:
+    with wave.open(str(audio_path), "rb") as wav_file:
+        sample_rate = wav_file.getframerate()
+        channels = wav_file.getnchannels()
+        frames_per_chunk = int(sample_rate * chunk_duration)
+
+        async with websockets.connect(uri, ping_interval=None) as websocket:
+            config_payload = {
+                "type": "ListenV1Configure",
+                "sample_rate": sample_rate,
+                "channels": channels,
+            }
+            if language:
+                config_payload["language"] = language
+            await websocket.send(json.dumps(config_payload))
+
+            while True:
+                frames = wav_file.readframes(frames_per_chunk)
+                if not frames:
+                    break
+                await websocket.send(frames)
+                await asyncio.sleep(chunk_duration)
+
+            await websocket.send(json.dumps({"type": "ListenV1Finalize"}))
+
+            async for message in websocket:
+                if isinstance(message, bytes):
+                    continue
+                payload = json.loads(message)
+                print(json.dumps(payload, indent=2))
+                if payload.get("type") == "utterance_end":
+                    break
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Stream audio to the local server.")
+    parser.add_argument("audio", type=Path, help="Path to a WAV file to stream")
+    parser.add_argument(
+        "--uri",
+        default="ws://127.0.0.1:9000/v1/listen",
+        help="Server WebSocket URI",
+    )
+    parser.add_argument(
+        "--chunk-duration",
+        type=float,
+        default=1.0,
+        help="Duration of each chunk in seconds",
+    )
+    parser.add_argument("--language", default=None, help="Optional language hint")
+    args = parser.parse_args()
+
+    asyncio.run(
+        simulate_stream(
+            args.audio,
+            uri=args.uri,
+            chunk_duration=args.chunk_duration,
+            language=args.language,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/test_websocket_client.py
+++ b/test_websocket_client.py
@@ -1,0 +1,58 @@
+"""Minimal WebSocket client for manual smoke testing."""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import math
+
+import numpy as np
+import websockets
+
+
+def generate_sine_wave(duration: float, frequency: float, sample_rate: int = 16000) -> bytes:
+    """Generate a PCM16 sine wave for testing."""
+
+    frame_count = int(duration * sample_rate)
+    times = np.linspace(0.0, duration, num=frame_count, endpoint=False)
+    waveform = 0.2 * np.sin(2 * math.pi * frequency * times)
+    pcm = np.clip(waveform * 32767, -32768, 32767).astype(np.int16)
+    return pcm.tobytes()
+
+
+async def run_client(uri: str, *, duration: float, frequency: float, language: str | None) -> None:
+    payload = generate_sine_wave(duration, frequency)
+    async with websockets.connect(uri, ping_interval=None) as websocket:
+        config = {"type": "ListenV1Configure", "sample_rate": 16000, "channels": 1}
+        if language:
+            config["language"] = language
+        await websocket.send(json.dumps(config))
+        await websocket.send(payload)
+        await websocket.send(json.dumps({"type": "ListenV1Finalize"}))
+
+        async for message in websocket:
+            if isinstance(message, bytes):
+                continue
+            data = json.loads(message)
+            print(json.dumps(data, indent=2))
+            if data.get("type") == "utterance_end":
+                break
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Simple WebSocket client test")
+    parser.add_argument(
+        "--uri",
+        default="ws://127.0.0.1:9000/v1/listen",
+        help="Server WebSocket URI",
+    )
+    parser.add_argument("--duration", type=float, default=2.0, help="Tone duration in seconds")
+    parser.add_argument("--frequency", type=float, default=440.0, help="Tone frequency in Hz")
+    parser.add_argument("--language", default=None, help="Optional language hint")
+    args = parser.parse_args()
+
+    asyncio.run(run_client(args.uri, duration=args.duration, frequency=args.frequency, language=args.language))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement a FastAPI WebSocket endpoint that mirrors Deepgram's listen API while streaming audio through lightning-whisper-mlx
- add transcription, audio chunking, and Deepgram adapter layers plus configuration and data models
- provide documentation and helper scripts for downloading audio, simulating realtime streams, and smoke testing the server

## Testing
- `python test_integration.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68e2e1cf7890832fb23c11cfeb0107f1